### PR TITLE
Adapt viewer width to windows

### DIFF
--- a/style/base.css
+++ b/style/base.css
@@ -94,6 +94,16 @@
 .grid-stack-item-content {
   color: var(--jp-content-font-color1);
   background-color: var(--jp-layout-color1);
+  display: flex;
+  flex-direction: column;
+}
+
+.grid-item-widget {
+  height: 100%;
+}
+
+.grid-item-widget > .jp-OutputArea-output {
+  display: block;
 }
 
 .grid-stack .grid-stack-item .grid-stack-item-content {


### PR DESCRIPTION
Fix partially #13 

Concerning the height, I think we should contribute to glue-jupyter to fix this. When using glue-jupyter inside JupyterLab's Notebook widget, we see that glue-jupyter outputs don't take the full available height.