### PR TITLE
Fixes YGlue observe

### DIFF
--- a/glue_lab/glue_ydoc.py
+++ b/glue_lab/glue_ydoc.py
@@ -1,5 +1,6 @@
 import json
-from typing import Dict, List
+from typing import Dict, List, Any, Callable
+from functools import partial
 
 from jupyter_ydoc.ybasedoc import YBaseDoc
 
@@ -41,9 +42,9 @@ class YGlue(YBaseDoc):
             self._ycontents.update(t, contents.items())
             self._ytabs.update(t, tabs.items())
 
-    def observe(self, callback):
+    def observe(self, callback: Callable[[str, Any], None]):
         self.unobserve()
-        self._subscriptions[self._ystate] = self._ystate.observe(callback)
-        self._subscriptions[self._ysource] = self._ysource.observe(callback)
-        self._subscriptions[self._ycontents] = self._ycontents.observe_deep(callback)
-        self._subscriptions[self._ytabs] = self._ytabs.observe_deep(callback)
+        self._subscriptions[self._ystate] = self._ystate.observe(partial(callback, "state"))
+        self._subscriptions[self._ysource] = self._ysource.observe(partial(callback, "source"))
+        self._subscriptions[self._ycontents] = self._ycontents.observe(partial(callback, "contents"))
+        self._subscriptions[self._ytabs] = self._ytabs.observe(partial(callback, "tabs"))

--- a/src/document/sharedModel.ts
+++ b/src/document/sharedModel.ts
@@ -17,11 +17,11 @@ export class GlueSessionSharedModel
   constructor() {
     super();
 
-    this._contents = this.ydoc.getMap<Y.Map<any>>('contents');
-    this._tabs = this.ydoc.getMap<Y.Map<Array<IDict>>>('tabs');
+    this._contents = this.ydoc.getMap<any>('contents');
+    this._tabs = this.ydoc.getMap<Array<IDict>>('tabs');
     this.undoManager.addToScope(this._contents);
-    this._contents.observeDeep(this._contentsObserver);
-    this._tabs.observeDeep(this._tabsObserver);
+    this._contents.observe(this._contentsObserver);
+    this._tabs.observe(this._tabsObserver);
   }
 
   dispose(): void {
@@ -60,22 +60,18 @@ export class GlueSessionSharedModel
     return new GlueSessionSharedModel();
   }
 
-  private _contentsObserver = (events: Y.YEvent<any>[]): void => {
-    if (events.length > 0) {
-      const contents = this.contents;
-      this._changed.emit(contents);
-      this._contentsChanged.emit(contents);
-    }
+  private _contentsObserver = (event: Y.YMapEvent<any>): void => {
+    const contents = this.contents;
+    this._changed.emit(contents);
+    this._contentsChanged.emit(contents);
   };
 
-  private _tabsObserver = (events: Y.YEvent<any>[]): void => {
-    if (events.length > 0) {
-      this._tabsChanged.emit({});
-    }
+  private _tabsObserver = (event: Y.YMapEvent<Array<IDict>>): void => {
+    this._tabsChanged.emit({});
   };
 
   private _contents: Y.Map<any>;
-  private _tabs: Y.Map<Y.Map<Array<IDict>>>;
+  private _tabs: Y.Map<Array<IDict>>;
 
   private _contentsChanged = new Signal<IGlueSessionSharedModel, IDict>(this);
   private _tabsChanged = new Signal<IGlueSessionSharedModel, IDict>(this);

--- a/src/document/sharedModel.ts
+++ b/src/document/sharedModel.ts
@@ -17,8 +17,8 @@ export class GlueSessionSharedModel
   constructor() {
     super();
 
-    this._contents = this.ydoc.getMap<any>('contents');
-    this._tabs = this.ydoc.getMap<Array<IDict>>('tabs');
+    this._contents = this.ydoc.getMap<IDict>('contents');
+    this._tabs = this.ydoc.getMap<IDict>('tabs');
     this.undoManager.addToScope(this._contents);
     this._contents.observe(this._contentsObserver);
     this._tabs.observe(this._tabsObserver);
@@ -60,18 +60,18 @@ export class GlueSessionSharedModel
     return new GlueSessionSharedModel();
   }
 
-  private _contentsObserver = (event: Y.YMapEvent<any>): void => {
+  private _contentsObserver = (event: Y.YMapEvent<IDict>): void => {
     const contents = this.contents;
     this._changed.emit(contents);
     this._contentsChanged.emit(contents);
   };
 
-  private _tabsObserver = (event: Y.YMapEvent<Array<IDict>>): void => {
+  private _tabsObserver = (event: Y.YMapEvent<IDict>): void => {
     this._tabsChanged.emit({});
   };
 
-  private _contents: Y.Map<any>;
-  private _tabs: Y.Map<Array<IDict>>;
+  private _contents: Y.Map<IDict>;
+  private _tabs: Y.Map<IDict>;
 
   private _contentsChanged = new Signal<IGlueSessionSharedModel, IDict>(this);
   private _tabsChanged = new Signal<IGlueSessionSharedModel, IDict>(this);


### PR DESCRIPTION
Fixes YGlue observe, and the shared model schema.

I simplified the schema because we were not creating the corresponding YMaps in the backend and we are not taking advantage of having a `Y.Map<Y.Map>>`.