### PR TITLE
Adds schema for the data and the links

### DIFF
--- a/glue_lab/glue_ydoc.py
+++ b/glue_lab/glue_ydoc.py
@@ -24,12 +24,9 @@ class YGlue(YBaseDoc):
         dataset = self._ydataset.to_json()
         links = self._ylinks.to_json()
         tabs = self._ytabs.to_json()
-        return json.dumps(dict(
-            contents=contents,
-            dataset=dataset,
-            links=links,
-            tabs=tabs
-            ))
+        return json.dumps(
+            dict(contents=contents, dataset=dataset, links=links, tabs=tabs)
+        )
 
     def set(self, value: str) -> None:
         """

--- a/glue_lab/glue_ydoc.py
+++ b/glue_lab/glue_ydoc.py
@@ -11,6 +11,8 @@ class YGlue(YBaseDoc):
         self._ysource = self._ydoc.get_text("source")
         self._ycontents = self._ydoc.get_map("contents")
         self._ytabs = self._ydoc.get_map("tabs")
+        self._ydataset = self._ydoc.get_map("dataset")
+        self._ylinks = self._ydoc.get_map("links")
 
     def get(self) -> str:
         """
@@ -38,9 +40,25 @@ class YGlue(YBaseDoc):
             for viewer in viewers[idx]:
                 tabs[tab].append(contents.get(viewer, {}))
 
+        data_collection_name: str = contents.get("__main__", {}).get("data", '')
+        data_names: List[str] = []
+        link_names: List[str] = []
+        if data_collection_name:
+            data_names = contents.get(data_collection_name, {}).get("data", [])
+            link_names = contents.get(data_collection_name, {}).get("links", [])
+
+        dataset: Dict[str, Dict] = {}
+        for data_name in data_names:
+            dataset[data_name] = contents.get(data_name, {})
+        links: Dict[str, Dict] = {}
+        for link_name in link_names:
+            links[link_name] = contents.get(link_name, {})
+
         with self._ydoc.begin_transaction() as t:
             self._ycontents.update(t, contents.items())
             self._ytabs.update(t, tabs.items())
+            self._ydataset.update(t, dataset.items())
+            self._ylinks.update(t, links.items())
 
     def observe(self, callback: Callable[[str, Any], None]):
         self.unobserve()

--- a/glue_lab/glue_ydoc.py
+++ b/glue_lab/glue_ydoc.py
@@ -40,7 +40,7 @@ class YGlue(YBaseDoc):
             for viewer in viewers[idx]:
                 tabs[tab].append(contents.get(viewer, {}))
 
-        data_collection_name: str = contents.get("__main__", {}).get("data", '')
+        data_collection_name: str = contents.get("__main__", {}).get("data", "")
         data_names: List[str] = []
         link_names: List[str] = []
         if data_collection_name:

--- a/glue_lab/glue_ydoc.py
+++ b/glue_lab/glue_ydoc.py
@@ -10,9 +10,9 @@ class YGlue(YBaseDoc):
         super().__init__(*args, **kwargs)
         self._ysource = self._ydoc.get_text("source")
         self._ycontents = self._ydoc.get_map("contents")
-        self._ytabs = self._ydoc.get_map("tabs")
         self._ydataset = self._ydoc.get_map("dataset")
         self._ylinks = self._ydoc.get_map("links")
+        self._ytabs = self._ydoc.get_map("tabs")
 
     def get(self) -> str:
         """
@@ -21,8 +21,15 @@ class YGlue(YBaseDoc):
         :rtype: Any
         """
         contents = self._ycontents.to_json()
+        dataset = self._ydataset.to_json()
+        links = self._ylinks.to_json()
         tabs = self._ytabs.to_json()
-        return json.dumps(dict(contents=contents, tabs=tabs))
+        return json.dumps(dict(
+            contents=contents,
+            dataset=dataset,
+            links=links,
+            tabs=tabs
+            ))
 
     def set(self, value: str) -> None:
         """
@@ -56,9 +63,9 @@ class YGlue(YBaseDoc):
 
         with self._ydoc.begin_transaction() as t:
             self._ycontents.update(t, contents.items())
-            self._ytabs.update(t, tabs.items())
             self._ydataset.update(t, dataset.items())
             self._ylinks.update(t, links.items())
+            self._ytabs.update(t, tabs.items())
 
     def observe(self, callback: Callable[[str, Any], None]):
         self.unobserve()
@@ -70,6 +77,12 @@ class YGlue(YBaseDoc):
         )
         self._subscriptions[self._ycontents] = self._ycontents.observe(
             partial(callback, "contents")
+        )
+        self._subscriptions[self._ydataset] = self._ydataset.observe(
+            partial(callback, "dataset")
+        )
+        self._subscriptions[self._ylinks] = self._ylinks.observe(
+            partial(callback, "links")
         )
         self._subscriptions[self._ytabs] = self._ytabs.observe(
             partial(callback, "tabs")

--- a/src/controlPanel/data/datasetsWidget.tsx
+++ b/src/controlPanel/data/datasetsWidget.tsx
@@ -61,10 +61,7 @@ export class DatasetsWidget extends ReactWidget {
 
     this._currentSharedModel = this._model.sharedModel;
     this._updateDataSets();
-    this._currentSharedModel.contentsChanged.connect(
-      this._updateDataSets,
-      this
-    );
+    this._currentSharedModel.datasetChanged.connect(this._updateDataSets, this);
   }
 
   private _updateDataSets() {

--- a/src/controlPanel/data/datasetsWidget.tsx
+++ b/src/controlPanel/data/datasetsWidget.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 
 import { CommandRegistry } from '@lumino/commands';
-import { JSONObject } from '@lumino/coreutils';
 import { Menu } from '@lumino/widgets';
 
 import { ReactWidget } from '@jupyterlab/ui-components';
@@ -73,19 +72,9 @@ export class DatasetsWidget extends ReactWidget {
       return;
     }
 
-    const mainModel = this._currentSharedModel.contents
-      .__main__ as JSONObject | null;
-
     this._currentSharedModel.changed.connect(this._updateDataSets, this);
 
-    if (!mainModel?.data) {
-      return;
-    }
-
-    const dataCollection =
-      this._currentSharedModel.contents[mainModel.data as string];
-
-    this._dataNames = (dataCollection as JSONObject | null)?.data as string[];
+    this._dataNames = Object.keys(this._currentSharedModel.dataset);
     this.update();
   }
 

--- a/src/document/sharedModel.ts
+++ b/src/document/sharedModel.ts
@@ -8,7 +8,11 @@ import {
   IGlueSessionSharedModel,
   IGlueSessionSharedModelChange
 } from '../types';
-import { IGlueSessionTabs } from '../_interface/glue.schema';
+import {
+  IGlueSessionDataset,
+  IGlueSessionLinks,
+  IGlueSessionTabs
+} from '../_interface/glue.schema';
 
 export class GlueSessionSharedModel
   extends YDocument<IGlueSessionSharedModelChange>
@@ -18,6 +22,8 @@ export class GlueSessionSharedModel
     super();
 
     this._contents = this.ydoc.getMap<IDict>('contents');
+    this._dataset = this.ydoc.getMap<IDict>('dataset');
+    this._links = this.ydoc.getMap<IDict>('links');
     this._tabs = this.ydoc.getMap<IDict>('tabs');
     this.undoManager.addToScope(this._contents);
     this._contents.observe(this._contentsObserver);
@@ -30,6 +36,14 @@ export class GlueSessionSharedModel
 
   get contents(): JSONObject {
     return JSONExt.deepCopy(this._contents.toJSON());
+  }
+
+  get dataset(): IGlueSessionDataset {
+    return JSONExt.deepCopy(this._dataset.toJSON());
+  }
+
+  get links(): IGlueSessionLinks {
+    return JSONExt.deepCopy(this._links.toJSON());
   }
 
   get tabs(): IGlueSessionTabs {
@@ -71,6 +85,8 @@ export class GlueSessionSharedModel
   };
 
   private _contents: Y.Map<IDict>;
+  private _dataset: Y.Map<IDict>;
+  private _links: Y.Map<IDict>;
   private _tabs: Y.Map<IDict>;
 
   private _contentsChanged = new Signal<IGlueSessionSharedModel, IDict>(this);

--- a/src/document/sharedModel.ts
+++ b/src/document/sharedModel.ts
@@ -27,6 +27,8 @@ export class GlueSessionSharedModel
     this._tabs = this.ydoc.getMap<IDict>('tabs');
     this.undoManager.addToScope(this._contents);
     this._contents.observe(this._contentsObserver);
+    this._dataset.observe(this._datasetObserver);
+    this._links.observe(this._linksObserver);
     this._tabs.observe(this._tabsObserver);
   }
 
@@ -52,6 +54,14 @@ export class GlueSessionSharedModel
 
   get contentsChanged(): ISignal<IGlueSessionSharedModel, IDict> {
     return this._contentsChanged;
+  }
+
+  get datasetChanged(): ISignal<IGlueSessionSharedModel, IDict> {
+    return this._datasetChanged;
+  }
+
+  get linksChanged(): ISignal<IGlueSessionSharedModel, IDict> {
+    return this._linksChanged;
   }
 
   get tabsChanged(): ISignal<IGlueSessionSharedModel, IDict> {
@@ -80,6 +90,14 @@ export class GlueSessionSharedModel
     this._contentsChanged.emit(contents);
   };
 
+  private _datasetObserver = (event: Y.YMapEvent<IDict>): void => {
+    this._datasetChanged.emit({});
+  };
+
+  private _linksObserver = (event: Y.YMapEvent<IDict>): void => {
+    this._linksChanged.emit({});
+  };
+
   private _tabsObserver = (event: Y.YMapEvent<IDict>): void => {
     this._tabsChanged.emit({});
   };
@@ -90,5 +108,7 @@ export class GlueSessionSharedModel
   private _tabs: Y.Map<IDict>;
 
   private _contentsChanged = new Signal<IGlueSessionSharedModel, IDict>(this);
+  private _datasetChanged = new Signal<IGlueSessionSharedModel, IDict>(this);
+  private _linksChanged = new Signal<IGlueSessionSharedModel, IDict>(this);
   private _tabsChanged = new Signal<IGlueSessionSharedModel, IDict>(this);
 }

--- a/src/linkPanel/widgets/linkedDataset.ts
+++ b/src/linkPanel/widgets/linkedDataset.ts
@@ -26,6 +26,8 @@ export class LinkedDataset extends LinkEditorWidget {
         { name: 'Inferred Links', widget: this._inferredLinksContent() }
       ])
     );
+
+    this._sharedModel.datasetChanged.connect(this.onDatasetChanged);
   }
 
   get selections(): [string, string] {
@@ -44,6 +46,10 @@ export class LinkedDataset extends LinkEditorWidget {
   }
 
   onSharedModelChanged(): void {
+    this.onDatasetChanged();
+  }
+
+  onDatasetChanged(): void {
     this._datasetSwitchers.forEach(switcher => {
       switcher.datasetList = Object.keys(this._sharedModel.dataset);
     });

--- a/src/linkPanel/widgets/linkedDataset.ts
+++ b/src/linkPanel/widgets/linkedDataset.ts
@@ -1,5 +1,4 @@
 import { ReactWidget, Toolbar } from '@jupyterlab/ui-components';
-import { JSONObject } from '@lumino/coreutils';
 import { ISignal, Signal } from '@lumino/signaling';
 import { BoxPanel, Widget } from '@lumino/widgets';
 
@@ -45,21 +44,8 @@ export class LinkedDataset extends LinkEditorWidget {
   }
 
   onSharedModelChanged(): void {
-    if (!this._sharedModel.contents.__main__) {
-      this._datasetSwitchers.forEach(switcher => {
-        switcher.datasetList = [];
-      });
-      return;
-    }
-
-    const dataCollection: string =
-      ((this._sharedModel.contents.__main__ as JSONObject).data as string) ||
-      '';
-    const datasetNames: string[] = (
-      this._sharedModel.contents[dataCollection] as JSONObject
-    ).data as string[];
     this._datasetSwitchers.forEach(switcher => {
-      switcher.datasetList = datasetNames;
+      switcher.datasetList = Object.keys(this._sharedModel.dataset);
     });
   }
 

--- a/src/linkPanel/widgets/linking.ts
+++ b/src/linkPanel/widgets/linking.ts
@@ -68,10 +68,6 @@ export class Linking extends LinkEditorWidget {
     });
   }
 
-  onSharedModelChanged(): void {
-    return;
-  }
-
   onAttributeClicked(attribute: Widget, index: number): void {
     const isSelected = attribute.hasClass('selected');
 

--- a/src/linkPanel/widgets/linking.ts
+++ b/src/linkPanel/widgets/linking.ts
@@ -6,7 +6,6 @@ import { BoxPanel, Panel, Widget } from '@lumino/widgets';
 import { LinkEditorWidget } from '../linkEditorWidget';
 import { AdvancedLinking } from './advancedLinkingChoices';
 import { LinkedDataset } from './linkedDataset';
-import { JSONObject } from '@lumino/coreutils';
 
 export class Linking extends LinkEditorWidget {
   constructor(options: Linking.IOptions) {
@@ -48,27 +47,21 @@ export class Linking extends LinkEditorWidget {
         this._identityAttributes[index].widgets[0].dispose();
       }
 
-      // Get the dataset object from model.
-      const datasetDefinition: JSONObject = this._sharedModel.contents[
-        dataName
-      ] as JSONObject;
-
       // Add a new widget for each attribute.
-      if (datasetDefinition) {
-        let attributes: string[] = datasetDefinition.primary_owner as string[];
+      let attributes: string[] =
+        this._sharedModel.dataset[dataName].primary_owner;
 
-        attributes = attributes.sort();
-        attributes.forEach(value => {
-          const attribute = new Widget();
-          attribute.title.label = value;
-          attribute.addClass('glue-LinkEditor-attribute');
-          attribute.node.innerText = value;
-          attribute.node.onclick = () => {
-            this.onAttributeClicked(attribute, index);
-          };
-          this._identityAttributes[index].addWidget(attribute);
-        });
-      }
+      attributes = attributes.sort();
+      attributes.forEach(value => {
+        const attribute = new Widget();
+        attribute.title.label = value;
+        attribute.addClass('glue-LinkEditor-attribute');
+        attribute.node.innerText = value;
+        attribute.node.onclick = () => {
+          this.onAttributeClicked(attribute, index);
+        };
+        this._identityAttributes[index].addWidget(attribute);
+      });
 
       // Updates the current dataset.
       this._currentDataset[index] = dataName;

--- a/src/linkPanel/widgets/summary.ts
+++ b/src/linkPanel/widgets/summary.ts
@@ -15,10 +15,6 @@ export class Summary extends LinkEditorWidget {
     );
   }
 
-  onSharedModelChanged(): void {
-    return;
-  }
-
   _identityLinksContent(): BoxPanel {
     const identityLinks = new BoxPanel();
     const links = new Widget();

--- a/src/schemas/dataset.schema.json
+++ b/src/schemas/dataset.schema.json
@@ -1,0 +1,59 @@
+{
+  "type": "object",
+  "description": "Dataset",
+  "title": "IDataset",
+  "required": ["_type", "components", "coords", "label", "primary_owner"],
+  "additionalProperties": false,
+  "properties": {
+    "_type": {
+      "const": "glue.core.data.Data"
+    },
+    "components": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "coords": {
+      "type": "string"
+    },
+    "label": {
+      "type": "string"
+    },
+    "meta": {
+      "type": "object",
+      "$ref": "#/definitions/meta"
+    },
+    "primary_owner": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "style": {
+      "type": "object",
+      "$ref": "#/definitions/style"
+    }
+  },
+  "definitions": {
+    "meta": {
+      "type": "object",
+      "properties": {
+        "_type": {
+          "const": "collections.OrderedDict"
+        },
+        "contents": {
+          "type": "object"
+        }
+      }
+    },
+    "style": {
+      "type": "object",
+      "properties": {
+        "_type": {
+          "const": "glue.core.visual.VisualAttributes"
+        }
+      }
+    }
+  }
+}

--- a/src/schemas/dataset.schema.json
+++ b/src/schemas/dataset.schema.json
@@ -39,9 +39,6 @@
     "meta": {
       "type": "object",
       "properties": {
-        "_type": {
-          "const": "collections.OrderedDict"
-        },
         "contents": {
           "type": "object"
         }
@@ -49,6 +46,7 @@
     },
     "style": {
       "type": "object",
+      "required": ["_type"],
       "properties": {
         "_type": {
           "const": "glue.core.visual.VisualAttributes"

--- a/src/schemas/dataset.schema.json
+++ b/src/schemas/dataset.schema.json
@@ -2,7 +2,7 @@
   "type": "object",
   "description": "Dataset",
   "title": "IDataset",
-  "required": ["_type", "components", "coords", "label", "primary_owner"],
+  "required": ["_type", "components", "label", "primary_owner"],
   "additionalProperties": false,
   "properties": {
     "_type": {

--- a/src/schemas/glue.schema.json
+++ b/src/schemas/glue.schema.json
@@ -7,11 +7,46 @@
     "contents": {
       "type": "object"
     },
+    "dataset": {
+      "$ref": "#/definitions/dataset"
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
     "tabs": {
       "$ref": "#/definitions/tabs"
     }
   },
   "definitions": {
+    "dataset": {
+      "title": "IGlueSessionDataset",
+      "type": "object",
+      "patternProperties": {
+        ".*": {
+          "$ref": "./dataset.schema.json"
+        }
+      }
+    },
+    "links": {
+      "title": "IGlueSessionLinks",
+      "type": "object",
+      "patternProperties": {
+        ".*": {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "./links/advancedLink.schema.json"
+              },
+              {
+                "$ref": "./links/componentLink.schema.json"
+              }
+            ]
+          }
+        }
+      },
+      "additionalProperties": false
+    },
     "tabs": {
       "title": "IGlueSessionTabs",
       "type": "object",

--- a/src/schemas/links/advancedLink.schema.json
+++ b/src/schemas/links/advancedLink.schema.json
@@ -1,0 +1,24 @@
+{
+  "type": "object",
+  "description": "AdvancedLink",
+  "title": "IAdvancedLink",
+  "required": ["_type", "cids1", "cids2", "data1", "data2"],
+  "additionalProperties": false,
+  "properties": {
+    "_type": {
+      "type": "string"
+    },
+    "cids1": {
+      "type": "string"
+    },
+    "cids2": {
+      "type": "string"
+    },
+    "data1": {
+      "type": "string"
+    },
+    "data2": {
+      "type": "string"
+    }
+  }
+}

--- a/src/schemas/links/componentLink.schema.json
+++ b/src/schemas/links/componentLink.schema.json
@@ -1,0 +1,42 @@
+{
+  "type": "object",
+  "description": "ComponentLink",
+  "title": "IComponentLink",
+  "required": ["_type", "frm", "to"],
+  "additionalProperties": false,
+  "properties": {
+    "_type": {
+      "const": "glue.core.component_link.ComponentLink"
+    },
+    "frm": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "inverse": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "string"
+      }
+    },
+    "to": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "using": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/src/schemas/links/componentLink.schema.json
+++ b/src/schemas/links/componentLink.schema.json
@@ -15,10 +15,7 @@
       }
     },
     "inverse": {
-      "type": [
-        "array",
-        "null"
-      ],
+      "type": ["array", "null"],
       "items": {
         "type": "string"
       }
@@ -30,10 +27,7 @@
       }
     },
     "using": {
-      "type": [
-        "array",
-        "null"
-      ],
+      "type": ["array", "null"],
       "items": {
         "type": "string"
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,6 +38,8 @@ export interface IGlueSessionSharedModel
   links: IGlueSessionLinks;
   tabs: IGlueSessionTabs;
   contentsChanged: ISignal<IGlueSessionSharedModel, IDict>;
+  datasetChanged: ISignal<IGlueSessionSharedModel, IDict>;
+  linksChanged: ISignal<IGlueSessionSharedModel, IDict>;
   tabsChanged: ISignal<IGlueSessionSharedModel, IDict>;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,11 @@ import { DocumentRegistry, IDocumentWidget } from '@jupyterlab/docregistry';
 import { JSONObject } from '@lumino/coreutils';
 import { ISignal } from '@lumino/signaling';
 import { Widget } from '@lumino/widgets';
-import { IGlueSessionTabs } from './_interface/glue.schema';
+import {
+  IGlueSessionDataset,
+  IGlueSessionLinks,
+  IGlueSessionTabs
+} from './_interface/glue.schema';
 
 export interface IDict<T = any> {
   [key: string]: T;
@@ -30,6 +34,8 @@ export interface IGlueSessionSharedModelChange {
 export interface IGlueSessionSharedModel
   extends YDocument<IGlueSessionSharedModelChange> {
   contents: JSONObject;
+  dataset: IGlueSessionDataset;
+  links: IGlueSessionLinks;
   tabs: IGlueSessionTabs;
   contentsChanged: ISignal<IGlueSessionSharedModel, IDict>;
   tabsChanged: ISignal<IGlueSessionSharedModel, IDict>;


### PR DESCRIPTION
This PR adds schema for the data and the links, and the corresponding attributes (*dataset* and *links*) to the `GlueSessionSharedModel`.

It includes the relevant modifications to use these new entries instead of parsing the `GlueSessionSharedModel.contents`.