### PR TITLE
Dynamic advanced links list

### DIFF
--- a/glue_lab/glue_utils.py
+++ b/glue_lab/glue_utils.py
@@ -7,28 +7,27 @@ load_plugins()
 
 def get_function_name(info):
     item = info[0]
-    if hasattr(item, 'display') and item.display is not None:
+    if hasattr(item, "display") and item.display is not None:
         return item.display
     else:
         return item.__name__
 
 
 def get_advanced_links():
-
     advanced_links: Dict[str, List] = {}
 
     for function in link_function.members:
         if len(function.output_labels) == 1:
-            if not function.category in advanced_links:
+            if function.category not in advanced_links:
                 advanced_links[function.category]: List[str] = []
             advanced_links[function.category].append(get_function_name(function))
 
     for helper in link_helper.members:
-        if not helper.category in advanced_links:
+        if helper.category not in advanced_links:
             advanced_links[helper.category]: List[str] = []
         advanced_links[helper.category].append(get_function_name(helper))
 
     # Reordering the dict
-    categories = ['General'] + sorted(set(advanced_links.keys()) - set(['General']))
+    categories = ["General"] + sorted(set(advanced_links.keys()) - set(["General"]))
     advanced_links = {k: sorted(advanced_links[k]) for k in categories}
     return advanced_links

--- a/glue_lab/glue_utils.py
+++ b/glue_lab/glue_utils.py
@@ -1,0 +1,34 @@
+from typing import List, Dict
+from glue.main import load_plugins
+from glue.config import link_function, link_helper
+
+load_plugins()
+
+
+def get_function_name(info):
+    item = info[0]
+    if hasattr(item, 'display') and item.display is not None:
+        return item.display
+    else:
+        return item.__name__
+
+
+def get_advanced_links():
+
+    advanced_links: Dict[str, List] = {}
+
+    for function in link_function.members:
+        if len(function.output_labels) == 1:
+            if not function.category in advanced_links:
+                advanced_links[function.category]: List[str] = []
+            advanced_links[function.category].append(get_function_name(function))
+
+    for helper in link_helper.members:
+        if not helper.category in advanced_links:
+            advanced_links[helper.category]: List[str] = []
+        advanced_links[helper.category].append(get_function_name(helper))
+
+    # Reordering the dict
+    categories = ['General'] + sorted(set(advanced_links.keys()) - set(['General']))
+    advanced_links = {k: sorted(advanced_links[k]) for k in categories}
+    return advanced_links

--- a/glue_lab/handlers.py
+++ b/glue_lab/handlers.py
@@ -13,10 +13,12 @@ class RouteHandler(APIHandler):
     # Jupyter server
     @tornado.web.authenticated
     def get(self, path):
-        if path == 'available-advanced-links':
+        if path == "available-advanced-links":
             self.finish(json.dumps({"data": get_advanced_links()}))
         else:
-            self.finish(json.dumps({"data": f"There is no endpoint at /glue-lab/{path}!"}))
+            self.finish(
+                json.dumps({"data": f"There is no endpoint at /glue-lab/{path}!"})
+            )
 
 
 def setup_handlers(web_app):

--- a/glue_lab/handlers.py
+++ b/glue_lab/handlers.py
@@ -4,20 +4,25 @@ from jupyter_server.base.handlers import APIHandler
 from jupyter_server.utils import url_path_join
 import tornado
 
+from .glue_utils import get_advanced_links
+
 
 class RouteHandler(APIHandler):
     # The following decorator should be present on all verb methods (head, get, post,
     # patch, put, delete, options) to ensure only authorized user can request the
     # Jupyter server
     @tornado.web.authenticated
-    def get(self):
-        self.finish(json.dumps({"data": "This is /glue-lab/get_example endpoint!"}))
+    def get(self, path):
+        if path == 'available-advanced-links':
+            self.finish(json.dumps({"data": get_advanced_links()}))
+        else:
+            self.finish(json.dumps({"data": f"There is no endpoint at /glue-lab/{path}!"}))
 
 
 def setup_handlers(web_app):
     host_pattern = ".*$"
 
     base_url = web_app.settings["base_url"]
-    route_pattern = url_path_join(base_url, "glue-lab", "get_example")
+    route_pattern = url_path_join(base_url, r"glue-lab/([^/]+)")
     handlers = [(route_pattern, RouteHandler)]
     web_app.add_handlers(host_pattern, handlers)

--- a/glue_lab/tests/test_handlers.py
+++ b/glue_lab/tests/test_handlers.py
@@ -8,4 +8,14 @@ async def test_get_example(jp_fetch):
     # Then
     assert response.code == 200
     payload = json.loads(response.body)
-    assert payload == {"data": "This is /glue-lab/get_example endpoint!"}
+    assert payload == {"data": "There is no endpoint at /glue-lab/get_example!"}
+
+
+async def test_get_advanced_links_list(jp_fetch):
+    # When
+    response = await jp_fetch("glue-lab", "available-advanced-links")
+
+    # Then
+    assert response.code == 200
+    payload = json.loads(response.body)
+    assert list(payload["data"].keys()) == ["General", "Astronomy", "Join"]

--- a/src/linkPanel/types.ts
+++ b/src/linkPanel/types.ts
@@ -9,6 +9,7 @@ export interface ILinkEditorModel {
   relatedLinks: Map<string, IComponentLinkInfo>;
   relatedLinksChanged: ISignal<this, void>;
   sharedModel: IGlueSessionSharedModel | undefined;
+  readonly availableAdvancedLinks: Promise<IAdvancedLinkCategories>;
 }
 
 export interface IComponentLinkInfo {
@@ -21,4 +22,8 @@ export interface ILinkInfo {
   attribute: string;
   dataset: string;
   label?: string;
+}
+
+export interface IAdvancedLinkCategories {
+  [group: string]: string[];
 }

--- a/src/linkPanel/widgets/linking.ts
+++ b/src/linkPanel/widgets/linking.ts
@@ -4,7 +4,7 @@ import { ReactWidget, Toolbar, ToolbarButton } from '@jupyterlab/ui-components';
 import { BoxPanel, Panel, Widget } from '@lumino/widgets';
 
 import { LinkEditorWidget } from '../linkEditorWidget';
-import { AdvancedLinking } from './advancedLinkingChoices';
+import { AdvancedLinkingChoices } from './advancedLinkingChoices';
 import { LinkedDataset } from './linkedDataset';
 
 export class Linking extends LinkEditorWidget {
@@ -102,7 +102,10 @@ export class Linking extends LinkEditorWidget {
     );
   };
 
-  advancedLinkChanged = (sender: AdvancedLinking, linkType: string): void => {
+  advancedLinkChanged = (
+    sender: AdvancedLinkingChoices,
+    linkType: string
+  ): void => {
     console.log(`Advanced link selected: '${linkType}'`);
   };
 
@@ -160,7 +163,10 @@ export class Linking extends LinkEditorWidget {
     const glueToolbar = new Toolbar();
     const attributes = new BoxPanel({ direction: 'left-to-right' });
 
-    const advancedSelect = new AdvancedLinking({});
+    const advancedSelect = new AdvancedLinkingChoices({
+      categories: this._linkEditorModel.availableAdvancedLinks
+    });
+
     this._advancedToolbar.push({
       name: 'Select advanced',
       widget: ReactWidget.create(advancedSelect.render())

--- a/src/linkPanel/widgets/summary.ts
+++ b/src/linkPanel/widgets/summary.ts
@@ -2,9 +2,9 @@ import { ReactWidget } from '@jupyterlab/ui-components';
 import { Panel, Widget } from '@lumino/widgets';
 
 import { LinkEditorWidget } from '../linkEditorWidget';
+import { IComponentLinkInfo } from '../types';
 import { LinkedDataset } from './linkedDataset';
 import { identityLinks } from './identityLinks';
-import { IComponentLinkInfo } from '../types';
 
 /**
  * The widget displaying the links for the selected dataset.

--- a/yarn.lock
+++ b/yarn.lock
@@ -9924,11 +9924,11 @@ __metadata:
 
 "typescript@patch:typescript@~5.0.4#~builtin<compat/typescript>":
   version: 5.0.4
-  resolution: "typescript@patch:typescript@npm%3A5.0.4#~builtin<compat/typescript>::version=5.0.4&hash=1f5320"
+  resolution: "typescript@patch:typescript@npm%3A5.0.4#~builtin<compat/typescript>::version=5.0.4&hash=85af82"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 6a1fe9a77bb9c5176ead919cc4a1499ee63e46b4e05bf667079f11bf3a8f7887f135aa72460a4c3b016e6e6bb65a822cb8689a6d86cbfe92d22cc9f501f09213
+  checksum: bb309d320c59a26565fb3793dba550576ab861018ff3fd1b7fccabbe46ae4a35546bc45f342c0a0b6f265c801ccdf64ffd68f548f117ceb7f0eac4b805cd52a9
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9924,11 +9924,11 @@ __metadata:
 
 "typescript@patch:typescript@~5.0.4#~builtin<compat/typescript>":
   version: 5.0.4
-  resolution: "typescript@patch:typescript@npm%3A5.0.4#~builtin<compat/typescript>::version=5.0.4&hash=85af82"
+  resolution: "typescript@patch:typescript@npm%3A5.0.4#~builtin<compat/typescript>::version=5.0.4&hash=1f5320"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: bb309d320c59a26565fb3793dba550576ab861018ff3fd1b7fccabbe46ae4a35546bc45f342c0a0b6f265c801ccdf64ffd68f548f117ceb7f0eac4b805cd52a9
+  checksum: 6a1fe9a77bb9c5176ead919cc4a1499ee63e46b4e05bf667079f11bf3a8f7887f135aa72460a4c3b016e6e6bb65a822cb8689a6d86cbfe92d22cc9f501f09213
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR allows to retrieves the available advanced links dynamically, using a rest API.

- adds a rest API handler 
- removes the default categories from `AdvancedLinkingChoices` in favor to the one get from API
 