### PR TITLE
Start kernel automatically without prompting

### DIFF
--- a/src/document/plugin.ts
+++ b/src/document/plugin.ts
@@ -64,6 +64,7 @@ export const gluePlugin: JupyterFrontEndPlugin<void> = {
       yWidgetManager: yWidgetManager,
       preferKernel: true,
       canStartKernel: true,
+      autoStartDefault: true,
       commands: app.commands
     });
     widgetFactory.widgetCreated.connect((_, widget) => {

--- a/src/viewPanel/sessionWidget.ts
+++ b/src/viewPanel/sessionWidget.ts
@@ -18,6 +18,7 @@ import { CommandRegistry } from '@lumino/commands';
 import { CommandIDs } from '../commands';
 import { IJupyterYWidgetManager } from 'yjs-widgets';
 
+
 export class SessionWidget extends BoxPanel {
   constructor(options: SessionWidget.IOptions) {
     super({ direction: 'top-to-bottom' });
@@ -130,9 +131,12 @@ export class SessionWidget extends BoxPanel {
 
     const future = kernel.requestExecute({ code }, false);
     await future.done;
+    this._dataLoaded.resolve();
   }
 
-  private _onTabsChanged(): void {
+  private async _onTabsChanged() {
+    await this._dataLoaded.promise;
+
     const tabNames = this._model.getTabNames();
 
     tabNames.forEach((tabName, idx) => {
@@ -147,8 +151,7 @@ export class SessionWidget extends BoxPanel {
         model: this._model,
         rendermime: this._rendermime,
         context: this._context,
-        notebookTracker: this._notebookTracker,
-        dataLoaded: this._dataLoaded
+        notebookTracker: this._notebookTracker
       }));
 
       this._tabPanel.addTab(tabWidget, idx + 1);

--- a/src/viewPanel/tabView.ts
+++ b/src/viewPanel/tabView.ts
@@ -16,7 +16,6 @@ import { DocumentRegistry } from '@jupyterlab/docregistry';
 import { GlueSessionModel } from '../document/docModel';
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 import { INotebookTracker } from '@jupyterlab/notebook';
-import { PromiseDelegate } from '@lumino/coreutils';
 
 export class TabView extends Widget {
   constructor(options: TabView.IOptions) {
@@ -336,6 +335,5 @@ export namespace TabView {
     rendermime: IRenderMimeRegistry;
     context: DocumentRegistry.IContext<GlueSessionModel>;
     notebookTracker: INotebookTracker;
-    dataLoaded: PromiseDelegate<void>;
   }
 }


### PR DESCRIPTION
Remove the "Choose kernel" prompt by starting the default kernel automatically. This only works if the default kernel is a Python kernel.

Doing this triggered a race condition where viewers would be created before the data were loaded, this PR fixes this race condition as well.