### PR TITLE
Fix data paths

### DIFF
--- a/glue_lab/glue_session.py
+++ b/glue_lab/glue_session.py
@@ -227,17 +227,16 @@ class SharedGlueSession:
         """Load data defined in the glue session"""
         data_paths = {}
         contents = self._document.contents
-        session_path = Path(self._path).parent
         if "LoadLog" in contents:
             path = Path(contents["LoadLog"]["path"])
-            data_paths[path.stem] = str(session_path / path)
+            data_paths[path.stem] = str(path)
         idx = 0
         while True:
             load_log = f"LoadLog_{idx}"
             if load_log not in contents:
                 break
             path = Path(contents[load_log]["path"])
-            data_paths[path.stem] = str(session_path / path)
+            data_paths[path.stem] = str(path)
             idx += 1
 
         for data_name, data_path in data_paths.items():

--- a/glue_lab/tests/conftest.py
+++ b/glue_lab/tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 from pathlib import Path
 from jupyter_ydoc import ydocs
@@ -20,6 +21,8 @@ def yglue_doc(session_path):
     with open(session_path, "r") as fobj:
         data = fobj.read()
 
+    os.chdir(Path(__file__).parents[2] / "examples")
+
     glue = ydocs["glu"]()
     glue.set(data)
 
@@ -38,6 +41,8 @@ def yglue_session(session_path, yglue_doc):
 def yglue_doc_links(session_links_path):
     with open(session_links_path, "r") as fobj:
         data = fobj.read()
+
+    os.chdir(Path(__file__).parents[2] / "examples")
 
     glue = ydocs["glu"]()
     glue.set(data)


### PR DESCRIPTION
We used to rely on a JupyterLab bug where the cwd of the started kernel would not be at the location of the session file that spawned the kernel.

Since JupyterLab 4.0.1 this was fixed, and we need to adapt our data loading code to load the data relative to the kernel.