### PR TITLE
Update rendering logic

### DIFF
--- a/glue_lab/glue_session.py
+++ b/glue_lab/glue_session.py
@@ -1,15 +1,16 @@
 import warnings
 from pathlib import Path
-from typing import Dict, Optional, Tuple
-from glue.core.link_helpers import LinkSame
+from typing import TYPE_CHECKING, Dict, Optional, Tuple
+
 import glue_jupyter as gj
 import y_py as Y
+from glue.core.link_helpers import LinkSame
 from IPython.display import display
 from ipywidgets import Output
 from jupyter_ydoc import ydocs
 from ypywidgets import Widget
-from typing import TYPE_CHECKING
 
+from .glue_utils import ErrorWidget
 from .glue_ydoc import COMPONENT_LINK_TYPE, IDENTITY_LINK_FUNCTION
 
 if TYPE_CHECKING:
@@ -175,7 +176,7 @@ class SharedGlueSession:
                     except Exception:
                         pass
             except Exception as e:
-                print(e)
+                widget = ErrorWidget(e, __file__)
 
         elif view_type == "glue.viewers.image.qt.data_viewer.ImageViewer":
             try:
@@ -191,7 +192,7 @@ class SharedGlueSession:
                     except Exception:
                         pass
             except Exception as e:
-                print(e)
+                widget = ErrorWidget(e, __file__)
         elif view_type == "glue.viewers.table.qt.data_viewer.TableViewer":
             try:
                 widget = self.app.table(data=viewer_data)
@@ -201,7 +202,7 @@ class SharedGlueSession:
                     except Exception:
                         pass
             except Exception as e:
-                print(e)
+                widget = ErrorWidget(e, __file__)
         return widget
 
     def _read_view_state(

--- a/glue_lab/glue_utils.py
+++ b/glue_lab/glue_utils.py
@@ -1,8 +1,11 @@
 import json
 from inspect import getfullargspec
-from typing import List, Dict
-from glue.main import load_plugins
+from typing import Dict, List
+
 from glue.config import link_function, link_helper
+from glue.main import load_plugins
+from IPython.display import display
+from ipywidgets import HTML
 
 load_plugins()
 
@@ -62,3 +65,14 @@ def get_advanced_links():
     categories = ["General"] + sorted(set(advanced_links.keys()) - set(["General"]))
     advanced_links = {k: advanced_links[k] for k in categories}
     return advanced_links
+
+
+class ErrorWidget:
+    """Wrapper of a HTML widget for showing error message"""
+
+    def __init__(self, e: Exception, path: str) -> None:
+        value = f"{type(e).__name__} at line {e.__traceback__.tb_lineno} of {path}: {e}"
+        self._widget = HTML(value=value)
+
+    def show(self):
+        display(self._widget)

--- a/glue_lab/tests/test_glue_session.py
+++ b/glue_lab/tests/test_glue_session.py
@@ -20,7 +20,7 @@ def test_create_viewer(yglue_session):
     yglue_session.create_viewer("Tab 1", "ScatterViewer")
     assert "Tab 1" in yglue_session._viewers
     assert "ScatterViewer" in yglue_session._viewers["Tab 1"]
-    assert yglue_session._viewers["Tab 1"]["ScatterViewer"]["rendered"] is False
+    assert yglue_session._viewers["Tab 1"]["ScatterViewer"]["widget"] is None
     assert isinstance(
         yglue_session._viewers["Tab 1"]["ScatterViewer"]["output"], Output
     )
@@ -43,7 +43,7 @@ def test_render_viewer(yglue_session):
     yglue_session._load_data()
     yglue_session.create_viewer("Tab 1", "ScatterViewer")
     yglue_session.render_viewer()
-    assert yglue_session._viewers["Tab 1"]["ScatterViewer"]["rendered"] is True
+    assert yglue_session._viewers["Tab 1"]["ScatterViewer"]["widget"] is not None
 
 
 def test_render_removed_viewer(yglue_session):

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -25,7 +25,8 @@ export function mockNotebook(
     },
     sessionContext: {
       session: null,
-      sessionChanged: signal
+      sessionChanged: signal,
+      kernelChanged: signal
     },
     disposed: signal,
     node: document.createElement('div')


### PR DESCRIPTION
This PR improves the widget rendering logic, the `create_viewer` and the `render_viewer` method now work independently. There are 2 scenarios:
- If `create_viewer` is called before `render_viewer`, the `create_viewer` will create empty outputs, and `render_viewer` will fill these outputs with the real widget.
- If `render_viewer` is called before `create_viewer`, the `render_viewer` will create the real widgets, and `create_viewer` will create outputs filled with widgets.
